### PR TITLE
Fix code scanning alert no. 8: Information exposure through an exception

### DIFF
--- a/flask_profiler/flask_profiler.py
+++ b/flask_profiler/flask_profiler.py
@@ -285,7 +285,8 @@ def registerInternalRouters(app):
             else:
                 return jsonify({"message": "No measurements found to delete."}), 404
         except Exception as e:
-            return jsonify({"error": f"An error occurred: {str(e)}"}), 500
+            logging.error("An error occurred: %s", str(e))
+            return jsonify({"error": "An internal error has occurred."}), 500
     
     @fp.route("/api/measurements/insert", methods=["POST"])
     @login_required
@@ -308,7 +309,8 @@ def registerInternalRouters(app):
                 return jsonify({"message": "Failed to insert measurement."}), 500
 
         except Exception as e:
-            return jsonify({"error": f"An error occurred: {str(e)}"}), 500
+            logging.error("An error occurred: %s", str(e))
+            return jsonify({"error": "An internal error has occurred."}), 500
         
     @fp.route("/api/webhook/save", methods=["POST"])
     @login_required
@@ -331,7 +333,8 @@ def registerInternalRouters(app):
                 return jsonify({"message": "Failed to save webhook."}), 500
 
         except Exception as e:
-            return jsonify({"error": f"An error occurred: {str(e)}"}), 500
+            logging.error("An error occurred: %s", str(e))
+            return jsonify({"error": "An internal error has occurred."}), 500
 
     @fp.route("/api/webhook/get", methods=["GET"])
     @login_required
@@ -347,7 +350,8 @@ def registerInternalRouters(app):
                 return jsonify({"error": "No webhook data found."}), 404
 
         except Exception as e:
-            return jsonify({"error": f"An error occurred: {str(e)}"}), 500
+            logging.error("An error occurred: %s", str(e))
+            return jsonify({"error": "An internal error has occurred."}), 500
     
     @fp.route("/api/measurements/<measurementId>".format(urlPath))
     @login_required


### PR DESCRIPTION
Fixes [https://github.com/Kalmai221/flask-profiler/security/code-scanning/8](https://github.com/Kalmai221/flask-profiler/security/code-scanning/8)

To fix the problem, we need to ensure that detailed exception information is not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by using Python's `logging` module to log the exception details and returning a generic error message in the response.

1. Import the `logging` module if it is not already imported.
2. Replace the current exception handling code to log the exception details and return a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
